### PR TITLE
merge span query work

### DIFF
--- a/lib/Elastica/Query/AbstractSpanQuery.php
+++ b/lib/Elastica/Query/AbstractSpanQuery.php
@@ -5,10 +5,10 @@ namespace Elastica\Query;
  * Abstract span query. Should be extended by all span query types.
  *
  * @author Marek Hernik <marek.hernik@gmail.com>
+ * @author Alessandro Chitolina <alekitto@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/span-queries.html
  */
 abstract class AbstractSpanQuery extends AbstractQuery
 {
-
 }

--- a/lib/Elastica/Query/SpanFirst.php
+++ b/lib/Elastica/Query/SpanFirst.php
@@ -4,37 +4,55 @@ namespace Elastica\Query;
 use Elastica\Exception\InvalidException;
 
 /**
- * SpanMulti query.
+ * SpanFirst query.
  *
- * @author Marek Hernik <marek.hernik@gmail.com>
  * @author Alessandro Chitolina <alekitto@gmail.com>
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
  */
-class SpanMulti extends AbstractSpanQuery
+class SpanFirst extends AbstractSpanQuery
 {
     /**
-     * Constructs a SpanMulti query object.
+     * Constructs a SpanFirst query object.
      *
      * @param \Elastica\Query\AbstractQuery|array $match OPTIONAL
+     * @param int $end OPTIONAL
      */
-    public function __construct($match = null)
+    public function __construct($match = null, $end = null)
     {
         if (null !== $match) {
             $this->setMatch($match);
+        }
+
+        if (null !== $end) {
+            $this->setEnd($end);
         }
     }
 
     /**
      * Set the query to be wrapped into the span multi query.
      *
-     * @param \Elastica\Query\AbstractQuery|array $args Matching query
+     * @param \Elastica\Query\AbstractSpanQuery|array $args Matching query
      *
      * @return $this
      */
     public function setMatch($args)
     {
         return $this->_addQuery('match', $args);
+    }
+
+    /**
+     * Set the maximum end position for the match query.
+     *
+     * @param int $end
+     *
+     * @return $this
+     */
+    public function setEnd($end)
+    {
+        $this->setParam('end', $end);
+
+        return $this;
     }
 
     /**
@@ -49,8 +67,8 @@ class SpanMulti extends AbstractSpanQuery
      */
     protected function _addQuery($type, $args)
     {
-        if (!is_array($args) && !($args instanceof AbstractQuery)) {
-            throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractQuery');
+        if (!is_array($args) && !($args instanceof AbstractSpanQuery)) {
+            throw new InvalidException('Invalid parameter. Has to be array or instance of Elastica\Query\AbstractSpanQuery');
         }
 
         return $this->setParam($type, $args);

--- a/lib/Elastica/Query/SpanTerm.php
+++ b/lib/Elastica/Query/SpanTerm.php
@@ -4,6 +4,7 @@ namespace Elastica\Query;
 /**
  * SpanTerm query.
  *
+ * @author Alessandro Chitolina <alekitto@gmail.com>
  * @author Marek Hernik <marek.hernik@gmail.com>
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
@@ -13,26 +14,37 @@ class SpanTerm extends AbstractSpanQuery
     /**
      * Constructs the SpanTerm query object.
      *
-     * @param string $field
-     * @param string $value
-     * @param float $boost OPTIONAL Boost value (default = 1)
+     * @param array $term OPTIONAL Calls setRawTerm with the given $term array
      */
-    public function __construct($field, $value, $boost = 1.0)
+    public function __construct(array $term = [])
     {
-        $this->setRawTerm($field, $value, $boost);
+        $this->setRawTerm($term);
     }
 
     /**
-     * Sets the query expression for a key with its boost value.
+     * Set term can be used instead of setTerm if some more special
+     * values for a term have to be set.
      *
-     * @param string $field
-     * @param string $value
-     * @param float $boost
+     * @param array $term Term array
      *
      * @return $this
      */
-    public function setRawTerm($field, $value, $boost = 1.0)
+    public function setRawTerm(array $term)
     {
-        return $this->setParam($field, ['value' => $value, 'boost' => $boost]);
+        return $this->setParams($term);
+    }
+
+    /**
+     * Adds a term to the term query.
+     *
+     * @param string       $key   Key to query
+     * @param string|array $value Values(s) for the query. Boost can be set with array
+     * @param float        $boost OPTIONAL Boost value (default = 1.0)
+     *
+     * @return $this
+     */
+    public function setTerm($key, $value, $boost = 1.0)
+    {
+        return $this->setRawTerm([$key => ['value' => $value, 'boost' => $boost]]);
     }
 }

--- a/lib/Elastica/QueryBuilder/DSL/Query.php
+++ b/lib/Elastica/QueryBuilder/DSL/Query.php
@@ -2,7 +2,6 @@
 namespace Elastica\QueryBuilder\DSL;
 
 use Elastica\Exception\NotImplementedException;
-use Elastica\Query\AbstractQuery;
 use Elastica\Query\BoolQuery;
 use Elastica\Query\Boosting;
 use Elastica\Query\Common;
@@ -27,6 +26,7 @@ use Elastica\Query\QueryString;
 use Elastica\Query\Range;
 use Elastica\Query\Regexp;
 use Elastica\Query\SimpleQueryString;
+use Elastica\Query\SpanFirst;
 use Elastica\Query\SpanMulti;
 use Elastica\Query\SpanNear;
 use Elastica\Query\SpanOr;
@@ -356,23 +356,28 @@ class Query implements DSL
     /**
      * span first query.
      *
+     * @param \Elastica\Query\AbstractQuery|array $match
+     * @param int $end
+     *
+     * @return SpanFirst
+     *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-first-query.html
      */
-    public function span_first()
+    public function span_first($match = null, $end = null)
     {
-        throw new NotImplementedException();
+        return new SpanFirst($match, $end);
     }
 
     /**
      * span multi term query.
      *
-     * @param AbstractQuery $match
+     * @param \Elastica\Query\AbstractQuery|array $match
      *
      * @return SpanMulti
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html
      */
-    public function span_multi_term(AbstractQuery $match = null)
+    public function span_multi_term($match = null)
     {
         return new SpanMulti($match);
     }
@@ -420,17 +425,15 @@ class Query implements DSL
     /**
      * span_term query.
      *
-     * @param string $field
-     * @param string $value
-     * @param float $boost OPTIONAL
+     * @param array $term
      *
      * @return SpanTerm
      *
      * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html
      */
-    public function span_term($field, $value, $boost = 1.0)
+    public function span_term(array $term = [])
     {
-        return new SpanTerm($field, $value, $boost);
+        return new SpanTerm($term);
     }
 
     /**

--- a/test/Elastica/Query/SpanFirstTest.php
+++ b/test/Elastica/Query/SpanFirstTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Elastica\Test\Query;
+
+use Elastica\Document;
+use Elastica\Query\SpanFirst;
+use Elastica\Query\SpanTerm;
+use Elastica\Test\Base as BaseTest;
+
+class SpanFirstTest extends BaseTest
+{
+    /**
+     * @group unit
+     */
+    public function testToArray()
+    {
+        $query = new SpanFirst();
+        $query->setMatch(new SpanTerm(['user' => 'kimchy']));
+        $query->setEnd(3);
+
+        $data = $query->toArray();
+
+        $this->assertEquals([
+            'span_first' => [
+                'match' => [
+                    'span_term' => ['user' => 'kimchy'],
+                ],
+                'end' => 3,
+            ],
+        ], $data);
+    }
+
+    /**
+     * @group functional
+     */
+    public function testSpanNearTerm()
+    {
+        $field = 'lorem';
+        $value = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse odio lacus, aliquam nec nulla quis, aliquam eleifend eros.';
+
+        $index = $this->_createIndex();
+        $type = $index->getType('test');
+
+        $docHitData = [$field => $value];
+        $doc = new Document(1, $docHitData);
+        $type->addDocument($doc);
+        $index->refresh();
+
+        $spanTerm = new SpanTerm([$field => ['value' => 'consectetur']]);
+
+        // consectetur, end 4 won't match
+        $spanNearQuery = new SpanFirst($spanTerm, 4);
+        $resultSet = $type->search($spanNearQuery);
+        $this->assertEquals(0, $resultSet->count());
+
+        $spanTerm = new SpanTerm([$field => ['value' => 'lorem']]);
+
+        // lorem, end 3 matches
+        $spanNearQuery = new SpanFirst($spanTerm, 3);
+        $resultSet = $type->search($spanNearQuery);
+        $this->assertEquals(1, $resultSet->count());
+    }
+}

--- a/test/Elastica/Query/SpanMultiTest.php
+++ b/test/Elastica/Query/SpanMultiTest.php
@@ -14,15 +14,6 @@ class SpanMultiTest extends BaseTest
 {
     /**
      * @group unit
-     * @expectedException \Elastica\Exception\InvalidException
-     */
-    public function testConstructWrongTypeInvalid()
-    {
-        $spanMultiQuery = new SpanMulti(new Term());
-    }
-
-    /**
-     * @group unit
      */
     public function testConstructValid()
     {

--- a/test/Elastica/Query/SpanNearTest.php
+++ b/test/Elastica/Query/SpanNearTest.php
@@ -26,8 +26,8 @@ class SpanNearTest extends BaseTest
     public function testConstructValid()
     {
         $field = 'name';
-        $spanTermQuery1 = new SpanTerm($field, 'marek', 1.5);
-        $spanTermQuery2 = new SpanTerm($field, 'nicolas');
+        $spanTermQuery1 = new SpanTerm([$field => ['value' => 'marek', 'boost' => 1.5]]);
+        $spanTermQuery2 = new SpanTerm([$field => 'nicolas']);
 
         $spanNearQuery = new SpanNear([$spanTermQuery1, $spanTermQuery2], 5, true);
 
@@ -44,10 +44,7 @@ class SpanNearTest extends BaseTest
                     ],
                     [
                         'span_term' => [
-                            'name' => [
-                                'value' => 'nicolas',
-                                'boost' => 1,
-                            ],
+                            'name' => 'nicolas',
                         ],
                     ],
 
@@ -76,8 +73,8 @@ class SpanNearTest extends BaseTest
         $type->addDocument($doc);
         $index->refresh();
 
-        $spanTermQuery1 = new SpanTerm($field, 'adipiscing');
-        $spanTermQuery2 = new SpanTerm($field, 'lorem');
+        $spanTermQuery1 = new SpanTerm([$field => 'adipiscing']);
+        $spanTermQuery2 = new SpanTerm([$field => 'lorem']);
 
         //slop range 4 won't match
         $spanNearQuery = new SpanNear([$spanTermQuery1, $spanTermQuery2], 4);
@@ -94,7 +91,7 @@ class SpanNearTest extends BaseTest
         $resultSet = $type->search($spanNearQuery);
         $this->assertEquals(0, $resultSet->count());
 
-        $spanNearQuery->addClause(new SpanTerm($field, 'consectetur'));
+        $spanNearQuery->addClause(new SpanTerm([$field => 'consectetur']));
         $spanNearQuery->setInOrder(false);
         $resultSet = $type->search($spanNearQuery);
         $this->assertEquals(1, $resultSet->count());

--- a/test/Elastica/Query/SpanOrTest.php
+++ b/test/Elastica/Query/SpanOrTest.php
@@ -26,8 +26,8 @@ class SpanOrTest extends BaseTest
     public function testConstructValid()
     {
         $field = 'name';
-        $spanTermQuery1 = new SpanTerm($field, 'marek', 1.5);
-        $spanTermQuery2 = new SpanTerm($field, 'nicolas');
+        $spanTermQuery1 = new SpanTerm([$field => ['value' => 'marek', 'boost' => 1.5]]);
+        $spanTermQuery2 = new SpanTerm([$field => 'nicolas']);
 
         $spanOrQuery = new SpanOr([$spanTermQuery1, $spanTermQuery2]);
 
@@ -44,10 +44,7 @@ class SpanOrTest extends BaseTest
                     ],
                     [
                         'span_term' => [
-                            'name' => [
-                                'value' => 'nicolas',
-                                'boost' => 1,
-                            ],
+                            'name' => 'nicolas',
                         ],
                     ],
 
@@ -79,15 +76,15 @@ class SpanOrTest extends BaseTest
         $index->refresh();
 
         //all 3 docs match
-        $spanTermQuery1 = new SpanTerm($field, 'lorem');
-        $spanTermQuery2 = new SpanTerm($field, 'ipsum');
+        $spanTermQuery1 = new SpanTerm([$field => 'lorem']);
+        $spanTermQuery2 = new SpanTerm([$field => 'ipsum']);
         $spanOrQuery = new SpanOr([$spanTermQuery1, $spanTermQuery2]);
         $resultSet = $type->search($spanOrQuery);
         $this->assertEquals(3, $resultSet->count());
 
         //only 1 match hit
-        $spanTermQuery1 = new SpanTerm($field, 'amet');
-        $spanTermQuery2 = new SpanTerm($field, 'sit');
+        $spanTermQuery1 = new SpanTerm([$field => 'amet']);
+        $spanTermQuery2 = new SpanTerm([$field => 'sit']);
         $spanOrQuery = new SpanOr([$spanTermQuery1, $spanTermQuery2]);
         $resultSet = $type->search($spanOrQuery);
         $this->assertEquals(1, $resultSet->count());

--- a/test/Elastica/Query/SpanTermTest.php
+++ b/test/Elastica/Query/SpanTermTest.php
@@ -14,14 +14,11 @@ class SpanTermTest extends BaseTest
     {
         $field = 'name';
         $value = 'marek';
-        $query = new SpanTerm($field, $value);
+        $query = new SpanTerm([$field => $value]);
 
         $expectedArray = [
             'span_term' => [
-                $field => [
-                    'value' => $value,
-                    'boost' => 1.0
-                ],
+                $field => $value,
             ],
         ];
 
@@ -47,7 +44,7 @@ class SpanTermTest extends BaseTest
         $type->addDocuments([$doc1, $doc2]);
         $index->refresh();
 
-        $query = new SpanTerm($field, $value);
+        $query = new SpanTerm([$field => $value]);
         $resultSet = $type->search($query);
         $results = $resultSet->getResults();
         $hitData = reset($results)->getData();

--- a/test/Elastica/QueryBuilder/DSL/QueryTest.php
+++ b/test/Elastica/QueryBuilder/DSL/QueryTest.php
@@ -69,13 +69,13 @@ class QueryTest extends AbstractDSLTest
         $this->_assertImplemented($queryDSL, 'exists', Query\Exists::class, ['field']);
         $this->_assertImplemented($queryDSL, 'type', Query\Type::class, []);
         $this->_assertImplemented($queryDSL, 'type', Query\Type::class, ['type']);
-        $this->_assertImplemented($queryDSL, 'span_term', Query\SpanTerm::class, ['field', 'value', 1.0]);
+        $this->_assertImplemented($queryDSL, 'span_term', Query\SpanTerm::class, []);
         $this->_assertImplemented($queryDSL, 'span_multi_term', Query\SpanMulti::class, []);
         $this->_assertImplemented($queryDSL, 'span_near', Query\SpanNear::class, []);
         $this->_assertImplemented($queryDSL, 'span_or', Query\SpanOr::class, []);
+        $this->_assertImplemented($queryDSL, 'span_first', Query\SpanFirst::class, []);
 
         $this->_assertNotImplemented($queryDSL, 'geo_shape', []);
-        $this->_assertNotImplemented($queryDSL, 'span_first', []);
         $this->_assertNotImplemented($queryDSL, 'span_not', []);
 
     }


### PR DESCRIPTION
See https://github.com/ruflin/Elastica/pull/1320#issuecomment-306274280

I've modified the `SpanTerm` query to match the `Term` query signature and the `SpanMulti` to accept a query as an array. This removes the checks on query type (wildcard, fuzzy, prefix or regex), but i think that these limitations should not be enforced by this library.